### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,6 @@ implementation is by Petru Paler and under a MIT licenses (AFAIK).
 .. |coveralls| image:: https://img.shields.io/coveralls/xj9/greyskull.svg
    :target: https://coveralls.io/r/xj9/greyskull
 
-.. |version| image:: https://pypip.in/version/Greyskull/badge.svg
+.. |version| image:: https://img.shields.io/pypi/v/Greyskull.svg
    :target: https://pypi.python.org/pypi/Greyskull/
    :alt: Latest Version


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20greyskull))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `greyskull`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.